### PR TITLE
Link the JSON schema in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "$schema" : "https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_config.schema.json",
     "name" : "bee",
     "words" : [ "require[%s%(\"']+bee%.%w+[%)\"']" ]
 }


### PR DESCRIPTION
Add the keyword $schema to the configuration file and link the schema
definition found in the LLS-Addons repository:

    https://raw.githubusercontent.com/LuaLS/LLS-Addons/main/schemas/addon_config.schema.json

Some editors like Visual Studio Code can use this schema to validate
the config.json.
